### PR TITLE
Add --parseable option for machine-parseable output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -121,6 +121,7 @@ yields:
     -s, --select <fn>   use the given <fn> for filtering
     -m, --map <fn>      use the given <fn> for mapping
     -c, --color         color the json output
+    -p, --parseable     make the json output machine-parseable
   
   
 ```

--- a/bin/jog
+++ b/bin/jog
@@ -49,6 +49,7 @@ program
   .option('-s, --select <fn>', 'use the given <fn> for filtering')
   .option('-m, --map <fn>', 'use the given <fn> for mapping')
   .option('-c, --color', 'color the json output')
+  .option('-p, --parseable', 'make the json output machine-parseable')
   .parse(process.argv);
 
 // determine store
@@ -120,6 +121,9 @@ stream.on('end', function(){
  */
 
 function output(obj) {
+  if (program.parseable) {
+    console.log(JSON.stringify(obj));
+  } else
   if (program.color) {
     console.log(util.inspect(obj, false, 15, true));
   } else {


### PR DESCRIPTION
Hacked together a [Jog server](http://jogwatcher.hughskennedy.com/) to make checking the logs a little more pleasant - was hoping to add quick map/reduce/etc. by piping output to the server, but the problem is that the output isn't parseable when using `JSON.parse`. Worth merging?
