### PR TITLE
Adds StdStore.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ test:
 		--require should \
 		test/jog.js \
 		test/FileStore.js \
-		test/RedisStore.js
+		test/RedisStore.js \
+		test/StdStore.js
 
 .PHONY: test

--- a/bin/jog
+++ b/bin/jog
@@ -77,11 +77,7 @@ var store = program.file
   ? new jog.FileStore(program.file)
   : program.redis
     ? new jog.RedisStore
-    : null;
-
-// no store
-
-if (!store) throw new Error('store required, use --file or --redis');
+    : new jog.StdStore;
 
 // -f
 

--- a/examples/stdstore.js
+++ b/examples/stdstore.js
@@ -1,0 +1,26 @@
+/**
+ * Example usage of StdStore.
+ *
+ * Run this example like: `node examples/stdstore.js` to see JSON output.
+ *
+ * After that play with piping the output to the `jog` CLI.
+ *
+ * Try:
+ *
+ * `node examples/stdstore.js 2>&1 | jog -f --map type`
+ * `node examples/stdstore.js 2>&1 | jog -f --level info`
+ * `node examples/stdstore.js 2>&1 | jog -f -c --level error`
+ *
+ * Note: You need to redirect stderr to stdout (2>&1) unless you set the
+ * `redirect` option to true when you create the StdStore().
+ */
+
+var Jog = require('..')
+  , log = new Jog(new Jog.StdStore());
+  //, log = new Jog(new Jog.StdStore({redirect: true}));
+
+log.info('module', {name: 'express', author: 'tjholowaychuk'});
+log.warn('module', {name: 'request', author: 'mikeal'});
+log.info('site', {url: 'http://npmjs.org'});
+log.info('module', {name: 'mkdirp', author: 'substack'});
+log.error('site', {url: 'http://expressjs.com'});

--- a/lib/jog.js
+++ b/lib/jog.js
@@ -3,7 +3,8 @@
  * Module dependencies.
  */
 
-var FileStore = require('./stores/FileStore')
+var StdStore = require('./stores/StdStore')
+  , FileStore = require('./stores/FileStore')
   , RedisStore = require('./stores/RedisStore');
 
 /**
@@ -22,6 +23,7 @@ exports.levels = ['debug', 'info', 'warn', 'error'];
  * Expose stores.
  */
 
+exports.StdStore = StdStore;
 exports.FileStore = FileStore;
 exports.RedisStore = RedisStore;
 
@@ -42,7 +44,7 @@ exports.RedisStore = RedisStore;
 
 function Jog(store, defaults) {
   if (!(this instanceof Jog)) return new Jog(store, defaults);
-  this.store = store;
+  this.store = store || new exports.StdStore();
   this.defaults = defaults;
 }
 

--- a/lib/stores/StdStore.js
+++ b/lib/stores/StdStore.js
@@ -21,7 +21,7 @@ module.exports = StdStore;
 function StdStore(options) {
   debug('stdstore');
   options = options || {};
-  this.merge = options.merge || false;
+  this.redirect = options.redirect || false;
   this.inStream = options.in || process.stdin;
   this.errStream = options.err || process.stderr;
   this.outStream = options.out || process.stdout;
@@ -36,7 +36,7 @@ function StdStore(options) {
 
 StdStore.prototype.add = function(obj){
   debug('add %j', obj);
-  if (!this.merge && (obj.level === 'error' || obj.level === 'warn')) {
+  if (!this.redirect && (obj.level === 'error' || obj.level === 'warn')) {
     this.errStream.write(JSON.stringify(obj) + '\n');
   }
   else {

--- a/lib/stores/StdStore.js
+++ b/lib/stores/StdStore.js
@@ -1,0 +1,94 @@
+
+/**
+ * Module depedencies.
+ */
+
+var debug = require('debug')('jog:std')
+  , EventEmitter = require('events').EventEmitter;
+
+/**
+ * Expose `StdStore`.
+ */
+
+module.exports = StdStore;
+
+/**
+ * Initialize a `StdStore`.
+ *
+ * @api public
+ */
+
+function StdStore() {
+  debug('stdstore');
+}
+
+/**
+ * Add `obj` to the file.
+ *
+ * @param {Object} obj
+ * @api private
+ */
+
+StdStore.prototype.add = function(obj){
+  debug('add %j', obj);
+  process.stdout.write(JSON.stringify(obj) + '\n');
+};
+
+/**
+ * Clear and invoke `fn()`.
+ *
+ * @param {Function} fn
+ * @api private
+ */
+
+StdStore.prototype.clear = function(fn){
+  debug('clear');
+  process.nextTick(fn);
+};
+
+/**
+ * Return an `EventEmitter` which emits "data"
+ * and "end" events.
+ *
+ * @param {Object} options
+ * @return {EventEmitter}
+ * @api private
+ */
+
+StdStore.prototype.stream = function(options){
+  var emitter = options.emitter || new EventEmitter
+    , options = options || {}
+    , buf = options.buf || ''
+    , self = this
+    , substr
+    , obj
+    , i;
+
+  // stream
+  var stream = process.stdin;
+  stream.resume();
+  stream.setEncoding('utf8');
+
+  stream.on('data', function(chunk){
+    buf += chunk
+    while (~(i = buf.indexOf('\n'))) {
+      substr = buf.slice(0, i);
+      if ('' == substr) break;
+      // We need to be more lenient with stdin than other stores.
+      try {
+        obj = JSON.parse(substr);
+      }
+      catch(e) {
+        obj = {type: substr};
+      }
+      emitter.emit('data', obj);
+      buf = buf.slice(i + 1);
+    }
+  });
+
+  stream.on('end', function(){
+    emitter.emit('end');
+  });
+
+  return emitter;
+};

--- a/lib/stores/StdStore.js
+++ b/lib/stores/StdStore.js
@@ -18,8 +18,13 @@ module.exports = StdStore;
  * @api public
  */
 
-function StdStore() {
+function StdStore(options) {
   debug('stdstore');
+  options = options || {};
+  this.merge = options.merge || false;
+  this.inStream = options.in || process.stdin;
+  this.errStream = options.err || process.stderr;
+  this.outStream = options.out || process.stdout;
 }
 
 /**
@@ -31,7 +36,12 @@ function StdStore() {
 
 StdStore.prototype.add = function(obj){
   debug('add %j', obj);
-  process.stdout.write(JSON.stringify(obj) + '\n');
+  if (!this.merge && (obj.level === 'error' || obj.level === 'warn')) {
+    this.errStream.write(JSON.stringify(obj) + '\n');
+  }
+  else {
+    this.outStream.write(JSON.stringify(obj) + '\n');
+  }
 };
 
 /**
@@ -65,9 +75,19 @@ StdStore.prototype.stream = function(options){
     , i;
 
   // stream
-  var stream = process.stdin;
+  var stream = this.inStream;
   stream.resume();
-  stream.setEncoding('utf8');
+  if (process.stdin === stream) {
+    stream.setEncoding('utf8');
+  }
+
+  // If this is not stdin, we should emit end after options.interval.
+  if (process.stdin !== stream && false !== options.end) {
+    setTimeout(function () {
+      stream.pause();
+      emitter.emit('end');
+    }, options.interval);
+  }
 
   stream.on('data', function(chunk){
     buf += chunk

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "devDependencies": {
     "mocha": "*",
     "should": "*",
-    "redis": "0.8.1"
+    "redis": "0.8.1",
+    "through": "*"
   },
   "main": "index",
   "engines": {

--- a/test/StdStore.js
+++ b/test/StdStore.js
@@ -1,0 +1,23 @@
+
+var Jog = require('../')
+  , through = require('through');
+
+describe('StdStore', function(){
+  var stream = through(
+    function write(data) {
+      var self = this;
+      process.nextTick(function(){
+        self.emit('data', data);
+      });
+    },
+    function end() {
+      this.emit('end');
+    }
+  );
+
+  require('./shared/Store')(new Jog.StdStore({
+    in: stream,
+    err: stream,
+    out: stream
+  }));
+})

--- a/test/shared/Store.js
+++ b/test/shared/Store.js
@@ -9,7 +9,7 @@ module.exports = function(store){
       log.write('info', 'compiling video', { vid: 'abc' });
       log.write('info', 'uploading video', { vid: 'abc' });
 
-      var stream = log.stream();
+      var stream = log.stream({ interval: 100 });
       var lines = [];
 
       stream.on('data', function(line){
@@ -53,7 +53,7 @@ module.exports = function(store){
       log.write('info', 'uploading video', { vid: 'abc' });
       log.clear(function(err){
         if (err) return done(err);
-        var stream = log.stream();
+        var stream = log.stream({ interval: 100 });
         var lines = [];
 
         stream.on('data', function(line){


### PR DESCRIPTION
Adds support for stdin and stdout. 

Uses StdStore as the default when no store is provided.

Allows you do do something like:

``` js
// app.js

var log = require('jog')();

log.info('Hello');
log.warn('World');
log.debug('Data', {
  property: 'foo',
  value: 'bar'
});
```

And then run it like:

```
$ node app.js 
{"level":"info","type":"Hello","timestamp":1350952923180}
{"level":"warn","type":"World","timestamp":1350952923181}
{"property":"foo","value":"bar","level":"debug","type":"Data","timestamp":1350952923181}
```

OR

```
$ node app.js | jog -f --map type
Hello
World
Data
```

OR

```
$ node app.js | jog -f --select "_.property === 'foo'"
{ property: 'foo',
  value: 'bar',
  level: 'debug',
  type: 'Data',
  timestamp: 1350953035191 }
```

You get the picture :)
