### PR TITLE
Removes dev deps unused in the tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,17 +7,15 @@
   , "repository": { "type": "git", "url": "git://github.com/visionmedia/jog.git" }
   , "bin": { "jog": "./bin/jog" }
   , "dependencies": {
-    "debug": "*",
-    "redis": "0.8.1",
-    "commander": "0.5.2",
-    "ms": "0.1.0"
-  }
+      "debug": "*",
+      "redis": "0.8.1",
+      "commander": "0.5.2",
+      "ms": "0.1.0"
+    }
   , "devDependencies": {
-    "mocha": "*",
-    "should": "*",
-    "JSONSelect": "*",
-    "canvas": "*"
-  }
+      "mocha": "*",
+      "should": "*"
+    }
   , "main": "index"
   , "engines": { "node": "*" }
 }


### PR DESCRIPTION
JSONSelect and canvas aren't used in the tests, only the examples.  canvas in particular is a pretty heavy dependency for anyone wanting to hack on jog.

If someone wants to run the canvas example they can `npm install canvas`.
