### PR TITLE
Removes redis dependency.

### DIFF
--- a/lib/stores/RedisStore.js
+++ b/lib/stores/RedisStore.js
@@ -4,8 +4,7 @@
  */
 
 var EventEmitter = require('events').EventEmitter
-  , debug = require('debug')('jog:redis')
-  , redis = require('redis');
+  , debug = require('debug')('jog:redis');
 
 /**
  * Expose `RedisStore`.
@@ -22,7 +21,7 @@ module.exports = RedisStore;
  */
 
 function RedisStore(client, key) {
-  this.db = client || redis.createClient();
+  this.db = client || require('redis').createClient();
   this.key = key || 'jog';
   this.rangeSize = 300;
 }

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   , "bin": { "jog": "./bin/jog" }
   , "dependencies": {
       "debug": "*",
-      "redis": "0.8.1",
       "commander": "0.5.2",
       "ms": "0.1.0"
     }
   , "devDependencies": {
       "mocha": "*",
-      "should": "*"
+      "should": "*",
+      "redis": "0.8.1"
     }
   , "main": "index"
   , "engines": { "node": "*" }


### PR DESCRIPTION
This updates RedisStore to only require('redis') if it needs to.  This is the same way socket.io does things so it seems reasonably standard.
