### PR TITLE
Replace named tokens in 'attrs.type'.

### DIFF
--- a/lib/jog.js
+++ b/lib/jog.js
@@ -99,6 +99,13 @@ Jog.prototype.write = function(level, type, attrs){
     });
   }
 
+  // Replace named tokens in `type`.
+  attrs.type = attrs.type.replace(/:([\w.]+)/g, function(token, name){
+    return name.split('.').reduce(function (attr, part) {
+      return attr[part] || null;
+    }, attrs) || token;
+  });
+
   // add it to the store
   this.store.add(attrs);
   return this;

--- a/test/jog.js
+++ b/test/jog.js
@@ -30,6 +30,23 @@ describe('Jog', function(){
       var log = new Jog(store);
       log.info('something happened');
     })
+
+    it('should replace named tokens', function (done) {
+      var store = {
+        add: function(obj) {
+          obj.type.should.equal('Hello Tobi!');
+          done();
+        }
+      };
+
+      var log = new Jog(store);
+      log.info(':greeting :name.first!', {
+        greeting: 'Hello',
+        name: {
+          first: 'Tobi'
+        }
+      });
+    })
   })
 
   describe('#ns(obj)', function(){


### PR DESCRIPTION
For example:

``` js
server.on('request', function (req, res) {
  var orig = res.end;
  res.end = function() {
    log.info('Request - :req.method :req.url (:status)', {
      status: res.statusCode,
      req: {
        method: req.method,
        url: req.url,
        // .. other req junk you want to log
      }
    });
    orig.apply(res, arguments);
  });
});
```

Might result in:

```
{type: 'Request - GET /foo.html (200)', timestamp: 123456789, req: { ... }}
```

Why do I want this?

(Pending the merge of the StdStore), I'd like to be able to 'watch' the logs in realtime only looking at the types, but later on I can look at the logs using jog's CLI with all the filtration options and whatnot.

This would allow dynamic types based on the other data without having to do any string formatting in your app code.

FYI this supports nested tokens such as `:name.first`, but does not currently support diving into Arrays at all.
