### PR TITLE
Formatters

### DIFF
--- a/bin/jog
+++ b/bin/jog
@@ -102,7 +102,7 @@ if (program.reduce) {
 
 // --output
 
-var formatters = jog.formatters();
+var formatters = jog.formatters(program.output);
 if (program.output) {
   var formatter = formatters[program.output];
 

--- a/bin/jog
+++ b/bin/jog
@@ -13,6 +13,10 @@ var maps = [];
 
 var selects = [];
 
+// reduce function
+
+var reduce;
+
 // --map
 
 program.on('map', function(val){
@@ -93,15 +97,29 @@ if (program.within) {
 // --reduce
 
 if (program.reduce) {
-  var reduce = new Function('$, _', 'return ' + program.reduce);
+  reduce = new Function('$, _', 'return ' + program.reduce);
 }
 
-// --output (check if formatter is valid)
+// --output
 
 var formatters = jog.formatters();
 if (program.output) {
-  if (!formatters[program.output] || !formatters[program.output].output) {
-    throw new Error('invalid output formatter');
+  var formatter = formatters[program.output];
+
+  if (!formatter || !formatter.output) {
+    throw new Error('invalid output formatter ' + program.output);
+  }
+
+  if (formatter.map) {
+    maps.push(formatter.map);
+  }
+
+  if (formatter.select) {
+    selects.push(formatter.select);
+  }
+
+  if (formatter.reduce) {
+    reduce = formatter.reduce;
   }
 }
 

--- a/bin/jog
+++ b/bin/jog
@@ -94,12 +94,6 @@ if (program.within) {
   selects.push(new Function('_', 'return Date.now() - _.timestamp <= ' + program.within));
 }
 
-// --reduce
-
-if (program.reduce) {
-  reduce = new Function('$, _', 'return ' + program.reduce);
-}
-
 // --output
 
 var formatters = jog.formatters()
@@ -118,19 +112,23 @@ if (program.output) {
   formatter = formatters.default;
 }
 
-if (formatter) {
-  if (!formatter.output) {
-    throw new Error('invalid output formatter ' + program.output);
-  }
-  if (formatter.map) {
-    maps.push(formatter.map);
-  }
-  if (formatter.select) {
-    selects.push(formatter.select);
-  }
-  if (formatter.reduce) {
-    reduce = formatter.reduce;
-  }
+if (!formatter.output) {
+  throw new Error('invalid output formatter ' + program.output);
+}
+if (formatter.map) {
+  maps.push(formatter.map);
+}
+if (formatter.select) {
+  selects.push(formatter.select);
+}
+if (formatter.reduce) {
+  reduce = formatter.reduce;
+}
+
+// --reduce
+
+if (program.reduce) {
+  reduce = new Function('$, _', 'return ' + program.reduce);
 }
 
 // setup

--- a/bin/jog
+++ b/bin/jog
@@ -63,8 +63,9 @@ program
   .option('-s, --select <fn>', 'use the given <fn> for filtering')
   .option('-m, --map <fn>', 'use the given <fn> for mapping')
   .option('-r, --reduce <fn>', 'use the given <fn> for reducing')
-  .option('-c, --color', 'color the output')
-  .option('-j, --json', 'output JSON (--color will not work)')
+  .option('-o, --output <name>', 'use the <name> output formatter')
+  .option('-c, --color', 'color the output (shortcut for --output color')
+  .option('-j, --json', 'output JSON (shortcut for --output json)')
   .parse(process.argv);
 
 // determine store
@@ -93,6 +94,15 @@ if (program.within) {
 
 if (program.reduce) {
   var reduce = new Function('$, _', 'return ' + program.reduce);
+}
+
+// --output (check if formatter is valid)
+
+var formatters = jog.formatters();
+if (program.output) {
+  if (!formatters[program.output] || !formatters[program.output].output) {
+    throw new Error('invalid output formatter');
+  }
 }
 
 // setup
@@ -146,11 +156,15 @@ stream.on('end', function(){
  */
 
 function output(obj) {
+  var line;
   if (program.json) {
-    console.log(JSON.stringify(obj, null, 2));
+    line = formatters.json.output(obj);
   } else if (program.color) {
-    console.log(util.inspect(obj, false, 15, true));
+    line = formatters.color.output(obj);
+  } else if (program.output) {
+    line = formatters[program.output].output(obj);
   } else {
-    console.log(obj);
+    line = obj;
   }
+  console.log(line);
 }

--- a/bin/jog
+++ b/bin/jog
@@ -102,22 +102,32 @@ if (program.reduce) {
 
 // --output
 
-var formatters = jog.formatters(program.output);
-if (program.output) {
-  var formatter = formatters[program.output];
+var formatters = jog.formatters()
+  , formatter;
 
-  if (!formatter || !formatter.output) {
+if (program.output) {
+  formatter = formatters[program.output];
+  if (!formatter) {
+    throw new Error('no formatter found for ' + program.output);
+  }
+} else if (program.json) {
+  formatter = formatters.json;
+} else if (program.color) {
+  formatter = formatters.color;
+} else {
+  formatter = formatters.default;
+}
+
+if (formatter) {
+  if (!formatter.output) {
     throw new Error('invalid output formatter ' + program.output);
   }
-
   if (formatter.map) {
     maps.push(formatter.map);
   }
-
   if (formatter.select) {
     selects.push(formatter.select);
   }
-
   if (formatter.reduce) {
     reduce = formatter.reduce;
   }
@@ -155,7 +165,7 @@ stream.on('data', function(line){
   }
 
   if (ignoreEOF) {
-    output(ret);
+    formatter.output([ret]);
   } else {
     results.push(ret);
   }
@@ -166,23 +176,5 @@ stream.on('data', function(line){
 stream.on('end', function(){
   if (ignoreEOF) return;
   if (reduce) results = results.reduce(reduce);
-  output(results);
+  formatter.output(results);
 });
-
-/**
- * Output `obj`.
- */
-
-function output(obj) {
-  var line;
-  if (program.json) {
-    line = formatters.json.output(obj);
-  } else if (program.color) {
-    line = formatters.color.output(obj);
-  } else if (program.output) {
-    line = formatters[program.output].output(obj);
-  } else {
-    line = obj;
-  }
-  console.log(line);
-}

--- a/examples/.jog/formatters/rainbow.js
+++ b/examples/.jog/formatters/rainbow.js
@@ -7,7 +7,9 @@ module.exports = {
   select: function(obj) {
     return obj.level === 'info';
   },
-  output: function(obj) {
-    return obj.rainbow;
+  output: function(lines) {
+    lines.forEach(function(line) {
+      console.log(line.rainbow);
+    });
   }
 };

--- a/examples/.jog/formatters/rainbow.js
+++ b/examples/.jog/formatters/rainbow.js
@@ -1,0 +1,13 @@
+require('colors');
+
+module.exports = {
+  map: function(obj) {
+    return obj.type;
+  },
+  select: function(obj) {
+    return obj.level === 'info';
+  },
+  output: function(obj) {
+    return obj.rainbow;
+  }
+};

--- a/lib/formatters/color.js
+++ b/lib/formatters/color.js
@@ -1,7 +1,9 @@
 var util = require('util');
 
 module.exports = {
-  output: function(obj) {
-    return util.inspect(obj, false, 15, true);
+  output: function(lines) {
+    lines.forEach(function(line) {
+      console.log(util.inspect(line, false, 15, true));
+    });
   }
 };

--- a/lib/formatters/color.js
+++ b/lib/formatters/color.js
@@ -1,0 +1,7 @@
+var util = require('util');
+
+module.exports = {
+  output: function(obj) {
+    return util.inspect(obj, false, 15, true);
+  }
+};

--- a/lib/formatters/default.js
+++ b/lib/formatters/default.js
@@ -1,0 +1,5 @@
+module.exports = {
+  output: function(lines) {
+    console.log(lines);
+  }
+};

--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -1,5 +1,5 @@
 module.exports = {
-  output: function(obj) {
-    return JSON.stringify(obj, null, 2);
+  output: function(lines) {
+    console.log(JSON.stringify(lines, null, 2));
   }
 };

--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -1,0 +1,5 @@
+module.exports = {
+  output: function(obj) {
+    return JSON.stringify(obj, null, 2);
+  }
+};

--- a/lib/formatters/short.js
+++ b/lib/formatters/short.js
@@ -1,7 +1,9 @@
 var util = require('util');
 
 module.exports = {
-  output: function(obj) {
-    return util.format('\x1B[90m%s\x1B[39m  %s', new Date(obj.timestamp).toLocaleString(), obj.type);
+  output: function(lines) {
+    lines.forEach(function(line) {
+      console.log(util.format('\x1B[90m%s\x1B[39m  %s', new Date(line.timestamp).toLocaleString(), line.type));
+    });
   }
 };

--- a/lib/formatters/short.js
+++ b/lib/formatters/short.js
@@ -1,0 +1,7 @@
+var util = require('util');
+
+module.exports = {
+  output: function(obj) {
+    return util.format('\x1B[90m%s\x1B[39m  %s', new Date(obj.timestamp).toLocaleString(), obj.type);
+  }
+};

--- a/lib/jog.js
+++ b/lib/jog.js
@@ -6,7 +6,8 @@
 var FileStore = require('./stores/FileStore')
   , RedisStore = require('./stores/RedisStore')
   , path = require('path')
-  , fs = require('fs');
+  , fs = require('fs')
+  , existsSync = fs.existsSync || path.existsSync;
 
 /**
  * Expose `Jog`.
@@ -30,7 +31,7 @@ exports.RedisStore = RedisStore;
 /**
  * Load formatters (sync).
  */
-exports.formatters = function() {
+exports.formatters = function(loadExtended) {
   var formatters = {};
 
   // Load core formatters.
@@ -39,6 +40,18 @@ exports.formatters = function() {
       formatters[file.slice(0, -3)] = require(path.join(__dirname, 'formatters', file));
     }
   });
+
+  if (loadExtended) {
+    // Load formatters relative to CWD.
+    var cwdPath = path.join(process.cwd(), '.jog', 'formatters');
+    if (existsSync(cwdPath)) {
+      fs.readdirSync(cwdPath).forEach(function(file) {
+        if (file.match(/\.js$/)) {
+          formatters[file.slice(0, -3)] = require(path.join(cwdPath, file));
+        }
+      });
+    }
+  }
 
   return formatters;
 };

--- a/lib/jog.js
+++ b/lib/jog.js
@@ -4,7 +4,9 @@
  */
 
 var FileStore = require('./stores/FileStore')
-  , RedisStore = require('./stores/RedisStore');
+  , RedisStore = require('./stores/RedisStore')
+  , path = require('path')
+  , fs = require('fs');
 
 /**
  * Expose `Jog`.
@@ -24,6 +26,22 @@ exports.levels = ['debug', 'info', 'warn', 'error'];
 
 exports.FileStore = FileStore;
 exports.RedisStore = RedisStore;
+
+/**
+ * Load formatters (sync).
+ */
+exports.formatters = function() {
+  var formatters = {};
+
+  // Load core formatters.
+  fs.readdirSync(path.join(__dirname, 'formatters')).forEach(function(file) {
+    if (file.match(/\.js$/)) {
+      formatters[file.slice(0, -3)] = require(path.join(__dirname, 'formatters', file));
+    }
+  });
+
+  return formatters;
+};
 
 /**
  * Initialize a new `Jog` log with

--- a/lib/jog.js
+++ b/lib/jog.js
@@ -31,7 +31,7 @@ exports.RedisStore = RedisStore;
 /**
  * Load formatters (sync).
  */
-exports.formatters = function(loadExtended) {
+exports.formatters = function() {
   var formatters = {};
 
   // Load core formatters.
@@ -41,16 +41,25 @@ exports.formatters = function(loadExtended) {
     }
   });
 
-  if (loadExtended) {
-    // Load formatters relative to CWD.
-    var cwdPath = path.join(process.cwd(), '.jog', 'formatters');
-    if (existsSync(cwdPath)) {
-      fs.readdirSync(cwdPath).forEach(function(file) {
-        if (file.match(/\.js$/)) {
-          formatters[file.slice(0, -3)] = require(path.join(cwdPath, file));
-        }
-      });
-    }
+  // Load formatters relative to HOME.
+  var home = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
+  var homePath = path.join(home, '.jog', 'formatters');
+  if (existsSync(homePath)) {
+    fs.readdirSync(homePath).forEach(function(file) {
+      if (file.match(/\.js$/)) {
+        formatters[file.slice(0, -3)] = require(path.join(homePath, file));
+      }
+    });
+  }
+
+  // Load formatters relative to CWD.
+  var cwdPath = path.join(process.cwd(), '.jog', 'formatters');
+  if (existsSync(cwdPath)) {
+    fs.readdirSync(cwdPath).forEach(function(file) {
+      if (file.match(/\.js$/)) {
+        formatters[file.slice(0, -3)] = require(path.join(cwdPath, file));
+      }
+    });
   }
 
   return formatters;


### PR DESCRIPTION
Introduces the concept of 'formatters' and ALL CLI output runs through a formatter.

A formatter is merely a commonjs module that exports an object.  The object should follow the following signature:

``` js
module.exports = {
  // Required. Outputs lines.
  output: function(lines) {
   // console.log, or write to a file, or whatever.
  },

  // Optional. Map function.
  map: function(obj) {
    return obj.type;
  },

  // Optional. Select function.
  select: function(obj) {
    return obj.level === 'error';
  },

  // Optional. Reduce function.
  reduce: function(lines) {
      // return reduced lines.
  }
};
```

Formatters can live in three possible locations:
- `lib/formatters`
- `$HOME/.jog/formatters`
- `$CWD/.jog/formatters`

This allows someone to maintain formatters that they like to use on either a per-machine, or per-project basis.  Awesome!  Also, the formatters are loaded in that order, so project formatters can override machine ones, or core ones.

Four core formatters are included:
- json
- color
- short
- default

You use the formatters via the `--output` command-line option.

```
jog -F /tmp/logs.log -f --output short

jog -F /tmp/logs.log -f -o short
```

`-j --json` is aliased to `--output json`

`-c --color` is aliased to `--output color`

I think this is a really flexible approach.  For example you could create a formatter that saves images, or a formatter that renders a CLI bar chart, or whatever.
