### PR TITLE
Check for error instances

### DIFF
--- a/lib/jog.js
+++ b/lib/jog.js
@@ -99,6 +99,11 @@ Jog.prototype.write = function(level, type, attrs){
     });
   }
 
+  // check for Error
+  if (attrs.error instanceof Error) {
+    attrs.error = attrs.error.stack || attrs.error.message;
+  }
+
   // add it to the store
   this.store.add(attrs);
   return this;

--- a/lib/jog.js
+++ b/lib/jog.js
@@ -100,8 +100,12 @@ Jog.prototype.write = function(level, type, attrs){
   }
 
   // check for Error
-  if (attrs.error instanceof Error) {
-    attrs.error = attrs.error.stack || attrs.error.message;
+  var err = attrs.error || attrs
+  if (err instanceof Error) {
+    attrs.error = {
+      stack:   err.stack,
+      message: err.message
+    };
   }
 
   // add it to the store

--- a/test/jog.js
+++ b/test/jog.js
@@ -36,14 +36,15 @@ describe('Jog', function(){
 
       var store = {
         add: function(obj){
-          obj.error.should.equal(err.stack);
-          obj.x.should.equal('y');
-          done();
+          obj.error.stack.should.equal(err.stack);
+          obj.error.message.should.equal(err.message);
         }
       };
 
       var log = new Jog(store);
-      log.error('something happened', { error: err, x: 'y' });
+      log.error('something happened', { error: err });
+      log.error('even worse', err);
+      done();
     })
   })
 

--- a/test/jog.js
+++ b/test/jog.js
@@ -30,6 +30,21 @@ describe('Jog', function(){
       var log = new Jog(store);
       log.info('something happened');
     })
+
+    it('should handle error instances', function (done){
+      var err = new Error('BOOM')
+
+      var store = {
+        add: function(obj){
+          obj.error.should.equal(err.stack);
+          obj.x.should.equal('y');
+          done();
+        }
+      };
+
+      var log = new Jog(store);
+      log.error('something happened', { error: err, x: 'y' });
+    })
   })
 
   describe('#ns(obj)', function(){


### PR DESCRIPTION
Picking up from the discussion at #6 (took me some time!)

Checks if `attrs.error` is an Error instance, and replaces it with the stacktrace as a string or the message if there is no stack attached.

Also there's a test case.
