### PR TITLE
Bug fix in FileStore

### DIFF
--- a/lib/stores/FileStore.js
+++ b/lib/stores/FileStore.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -67,8 +66,8 @@ FileStore.prototype.clear = function(fn){
  */
 
 FileStore.prototype.stream = function(options){
-  var emitter = options.emitter || new EventEmitter
-    , options = options || {}
+  var options = options || {}
+    , emitter = options.emitter || new EventEmitter
     , buf = options.buf || ''
     , self = this
     , substr


### PR DESCRIPTION
Fixed bug with undefined options var when stream() called with no param.
